### PR TITLE
Fix sensitivity propagation when building pwset node

### DIFF
--- a/Merger/src/main/kotlin/lushu/Merger/Lattice/Node/Node.kt
+++ b/Merger/src/main/kotlin/lushu/Merger/Lattice/Node/Node.kt
@@ -33,11 +33,15 @@ sealed class Node(
     }
 
     override fun toString(): String {
-        return "Node(charset=$charset interval=$interval)"
+        return "Node(charset=$charset interval=$interval sensitive=$sensitive)"
     }
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is Node -> this.charset == other.charset && this.interval == other.interval
+        is Node -> (
+            this.charset == other.charset &&
+                this.interval == other.interval &&
+                this.sensitive == other.sensitive
+            )
         else -> false
     }
 }
@@ -52,6 +56,11 @@ class IntervalNode(
     // respective base node interval.
     fun isWithinBounds(): Boolean {
         return interval.isWithinBound(baseNode.interval)
+    }
+
+    override fun toString(): String {
+        return "IntervalNode(baseNode=$baseNode charset=$charset interval=$interval " +
+            "sensitive=$sensitive)"
     }
 }
 
@@ -76,5 +85,10 @@ class PwsetNode(
 
     fun joinBlacklist(other: PwsetNode): Set<Int> {
         return blacklist.union(other.blacklist)
+    }
+
+    override fun toString(): String {
+        return "PwsetNode(id=$id blacklist=$blacklist charset=$charset " +
+            "interval=$interval sensitive=$sensitive)"
     }
 }

--- a/Merger/src/main/kotlin/lushu/Merger/Lattice/NodeFactory.kt
+++ b/Merger/src/main/kotlin/lushu/Merger/Lattice/NodeFactory.kt
@@ -129,7 +129,7 @@ class NodeFactory(
     ): PwsetNode {
         val nodeID = globalNodeID
         globalNodeID++
-        val newNode = PwsetNode(nodeID, blacklist, charset, interval)
+        val newNode = PwsetNode(nodeID, blacklist, charset, interval, sensitive)
         pwsetNodes[nodeID] = newNode
         return newNode
     }

--- a/Merger/src/test/kotlin/lushu/Merger/Lattice/MergerLatticeTest.kt
+++ b/Merger/src/test/kotlin/lushu/Merger/Lattice/MergerLatticeTest.kt
@@ -98,4 +98,80 @@ class MergerLatticeTest {
             }
         }
     }
+
+    @Test
+    fun meetSensitive() {
+        data class TestCase(
+            val desc: String,
+            val n1: Node,
+            val n2: Node,
+            val expected: Boolean
+        )
+        val testCases = listOf<TestCase>(
+            TestCase(
+                "both non-sensitive",
+                TestNodeBuilder.alphaIntervalNode(setOf<Char>('a'), 1, 1, false),
+                TestNodeBuilder.alphaIntervalNode(setOf<Char>('b'), 1, 1, false),
+                false
+            ),
+            TestCase(
+                "both sensitive",
+                TestNodeBuilder.alphaIntervalNode(setOf<Char>('a'), 1, 1, true),
+                TestNodeBuilder.alphaIntervalNode(setOf<Char>('b'), 1, 1, true),
+                true
+            ),
+            TestCase(
+                "first sensitive second non-sensitive",
+                TestNodeBuilder.alphaIntervalNode(setOf<Char>('a'), 1, 1, true),
+                TestNodeBuilder.alphaIntervalNode(setOf<Char>('b'), 1, 1, false),
+                true
+            ),
+            TestCase(
+                "first non-sensitive second sensitive",
+                TestNodeBuilder.alphaIntervalNode(setOf<Char>('a'), 1, 1, false),
+                TestNodeBuilder.alphaIntervalNode(setOf<Char>('b'), 1, 1, true),
+                true
+            ),
+            TestCase(
+                "first interval non-sensitive second pwset sensitive",
+                TestNodeBuilder.alphaIntervalNode(setOf<Char>('a'), 1, 1, false),
+                TestNodeBuilder.alphaBaseNode(true),
+                true
+            ),
+            TestCase(
+                "first pwset sensitive second interval non-sensitive",
+                TestNodeBuilder.alphaBaseNode(true),
+                TestNodeBuilder.alphaIntervalNode(setOf<Char>('a'), 1, 1, false),
+                true
+            ),
+            TestCase(
+                "both pwset non-sensitive",
+                TestNodeBuilder.alphaBaseNode(),
+                TestNodeBuilder.alphaBaseNode(),
+                false
+            ),
+            TestCase(
+                "both pwset sensitive",
+                TestNodeBuilder.alphaBaseNode(true),
+                TestNodeBuilder.alphaBaseNode(true),
+                true
+            ),
+            TestCase(
+                "pwset sensitive and non-sensitive",
+                TestNodeBuilder.alphaBaseNode(true),
+                TestNodeBuilder.alphaBaseNode(false),
+                true
+            )
+        )
+        testCases.forEach {
+            println("Starting test ${it.desc}")
+            val actual = lattice.meet(it.n1, it.n2)
+            if (it.expected != actual.sensitive) {
+                throw Exception(
+                    "For test '${it.desc}', expected ${it.expected}, " +
+                        "but got $actual"
+                )
+            }
+        }
+    }
 }

--- a/Merger/src/test/kotlin/lushu/Merger/TestUtils/TestNodeBuilder.kt
+++ b/Merger/src/test/kotlin/lushu/Merger/TestUtils/TestNodeBuilder.kt
@@ -7,30 +7,33 @@ import lushu.Merger.Lattice.Node.PwsetNode
 
 class TestNodeBuilder {
     companion object {
-        fun alphaBaseNode(): PwsetNode {
+        fun alphaBaseNode(sensitive: Boolean = false): PwsetNode {
             return PwsetNode(
                 1,
                 setOf<Int>(),
                 Charset(Fixtures.allAlphas),
-                Fixtures.testNodeInterval1To32()
+                Fixtures.testNodeInterval1To32(),
+                sensitive
             )
         }
 
-        fun numBaseNode(): PwsetNode {
+        fun numBaseNode(sensitive: Boolean = false): PwsetNode {
             return PwsetNode(
                 2,
                 setOf<Int>(),
                 Charset(Fixtures.allNums),
-                Fixtures.testNodeInterval1To32()
+                Fixtures.testNodeInterval1To32(),
+                sensitive
             )
         }
 
-        fun punctBaseNode(): PwsetNode {
+        fun punctBaseNode(sensitive: Boolean = false): PwsetNode {
             return PwsetNode(
                 3,
                 setOf<Int>(0, 1),
                 Charset(Fixtures.allPuncts),
-                Fixtures.testNodeInterval1To32()
+                Fixtures.testNodeInterval1To32(),
+                sensitive
             )
         }
 
@@ -48,24 +51,28 @@ class TestNodeBuilder {
         fun alphaIntervalNode(
             chars: Set<Char>,
             intervalMin: Int,
-            intervalMax: Int
+            intervalMax: Int,
+            sensitive: Boolean = false
         ): IntervalNode {
             return IntervalNode(
                 alphaBaseNode(),
                 Charset(chars),
-                Interval(intervalMin, intervalMax)
+                Interval(intervalMin, intervalMax),
+                sensitive
             )
         }
 
         fun punctIntervalNode(
             chars: Set<Char>,
             intervalMin: Int,
-            intervalMax: Int
+            intervalMax: Int,
+            sensitive: Boolean = false
         ): IntervalNode {
             return IntervalNode(
                 punctBaseNode(),
                 Charset(chars),
-                Interval(intervalMin, intervalMax)
+                Interval(intervalMin, intervalMax),
+                sensitive
             )
         }
 


### PR DESCRIPTION
Powerset lattice nodes were not being built considering the proper `sensitive` parameter passed as input.