### PR TITLE
Fix bug in pwset node build

### DIFF
--- a/Merger/src/main/kotlin/lushu/Merger/Lattice/Node/Node.kt
+++ b/Merger/src/main/kotlin/lushu/Merger/Lattice/Node/Node.kt
@@ -33,11 +33,15 @@ sealed class Node(
     }
 
     override fun toString(): String {
-        return "Node(charset=$charset interval=$interval)"
+        return "Node(charset=$charset interval=$interval sensitive=$sensitive)"
     }
 
     override fun equals(other: Any?): Boolean = when (other) {
-        is Node -> this.charset == other.charset && this.interval == other.interval
+        is Node -> (
+            this.charset == other.charset &&
+                this.interval == other.interval &&
+                this.sensitive == other.sensitive
+            )
         else -> false
     }
 }
@@ -52,6 +56,11 @@ class IntervalNode(
     // respective base node interval.
     fun isWithinBounds(): Boolean {
         return interval.isWithinBound(baseNode.interval)
+    }
+
+    override fun toString(): String {
+        return "IntervalNode(baseNode=$baseNode charset=$charset interval=$interval " +
+            "sensitive=$sensitive)"
     }
 }
 
@@ -76,5 +85,10 @@ class PwsetNode(
 
     fun joinBlacklist(other: PwsetNode): Set<Int> {
         return blacklist.union(other.blacklist)
+    }
+
+    override fun toString(): String {
+        return "PwsetNode(id=$id blacklist=$blacklist charset=$charset " +
+            "interval=$interval sensitive=$sensitive)"
     }
 }

--- a/Merger/src/main/kotlin/lushu/Merger/Lattice/NodeFactory.kt
+++ b/Merger/src/main/kotlin/lushu/Merger/Lattice/NodeFactory.kt
@@ -129,7 +129,7 @@ class NodeFactory(
     ): PwsetNode {
         val nodeID = globalNodeID
         globalNodeID++
-        val newNode = PwsetNode(nodeID, blacklist, charset, interval)
+        val newNode = PwsetNode(nodeID, blacklist, charset, interval, sensitive)
         pwsetNodes[nodeID] = newNode
         return newNode
     }

--- a/Merger/src/main/kotlin/lushu/Merger/Merger/Reducer.kt
+++ b/Merger/src/main/kotlin/lushu/Merger/Merger/Reducer.kt
@@ -35,7 +35,12 @@ class Reducer(private val lattice: MergerLattice) {
             // We want a node [a]{1,1}[b]{1,1}[c]{1,1} to become [abc]{3,3}
             reducedNodes[fmtIdx] = if (glb is IntervalNode) {
                 with(glb) {
-                    IntervalNode(baseNode, charset, interval.cap().increment())
+                    IntervalNode(
+                        baseNode,
+                        charset,
+                        interval.cap().increment(),
+                        sensitive
+                    )
                 }
             } else {
                 glb

--- a/Merger/src/main/kotlin/lushu/Merger/Merger/Zipper.kt
+++ b/Merger/src/main/kotlin/lushu/Merger/Merger/Zipper.kt
@@ -13,9 +13,6 @@ class Zipper(
         ns1: List<Node>,
         ns2: List<Node>
     ): List<Node> {
-        if (ns1.isEmpty()) {
-            return ns2
-        }
         if (ns1 == ns2) {
             return ns2
         }

--- a/Merger/src/test/kotlin/lushu/Merger/Lattice/MergerLatticeTest.kt
+++ b/Merger/src/test/kotlin/lushu/Merger/Lattice/MergerLatticeTest.kt
@@ -98,4 +98,80 @@ class MergerLatticeTest {
             }
         }
     }
+
+    @Test
+    fun meetSensitive() {
+        data class TestCase(
+            val desc: String,
+            val n1: Node,
+            val n2: Node,
+            val expected: Boolean
+        )
+        val testCases = listOf<TestCase>(
+            TestCase(
+                "both non-sensitive",
+                TestNodeBuilder.alphaIntervalNode(setOf<Char>('a'), 1, 1, false),
+                TestNodeBuilder.alphaIntervalNode(setOf<Char>('b'), 1, 1, false),
+                false
+            ),
+            TestCase(
+                "both sensitive",
+                TestNodeBuilder.alphaIntervalNode(setOf<Char>('a'), 1, 1, true),
+                TestNodeBuilder.alphaIntervalNode(setOf<Char>('b'), 1, 1, true),
+                true
+            ),
+            TestCase(
+                "first sensitive second non-sensitive",
+                TestNodeBuilder.alphaIntervalNode(setOf<Char>('a'), 1, 1, true),
+                TestNodeBuilder.alphaIntervalNode(setOf<Char>('b'), 1, 1, false),
+                true
+            ),
+            TestCase(
+                "first non-sensitive second sensitive",
+                TestNodeBuilder.alphaIntervalNode(setOf<Char>('a'), 1, 1, false),
+                TestNodeBuilder.alphaIntervalNode(setOf<Char>('b'), 1, 1, true),
+                true
+            ),
+            TestCase(
+                "first interval non-sensitive second pwset sensitive",
+                TestNodeBuilder.alphaIntervalNode(setOf<Char>('a'), 1, 1, false),
+                TestNodeBuilder.alphaBaseNode(true),
+                true
+            ),
+            TestCase(
+                "first pwset sensitive second interval non-sensitive",
+                TestNodeBuilder.alphaBaseNode(true),
+                TestNodeBuilder.alphaIntervalNode(setOf<Char>('a'), 1, 1, false),
+                true
+            ),
+            TestCase(
+                "both pwset non-sensitive",
+                TestNodeBuilder.alphaBaseNode(),
+                TestNodeBuilder.alphaBaseNode(),
+                false
+            ),
+            TestCase(
+                "both pwset sensitive",
+                TestNodeBuilder.alphaBaseNode(true),
+                TestNodeBuilder.alphaBaseNode(true),
+                true
+            ),
+            TestCase(
+                "pwset sensitive and non-sensitive",
+                TestNodeBuilder.alphaBaseNode(true),
+                TestNodeBuilder.alphaBaseNode(false),
+                true
+            )
+        )
+        testCases.forEach {
+            println("Starting test ${it.desc}")
+            val actual = lattice.meet(it.n1, it.n2)
+            if (it.expected != actual.sensitive) {
+                throw Exception(
+                    "For test '${it.desc}', expected ${it.expected}, " +
+                        "but got $actual"
+                )
+            }
+        }
+    }
 }

--- a/Merger/src/test/kotlin/lushu/Merger/Merger/MergerTest.kt
+++ b/Merger/src/test/kotlin/lushu/Merger/Merger/MergerTest.kt
@@ -26,11 +26,10 @@ class MergerTest {
         )
         val testCases = listOf<TestCase>(
             TestCase("empty", "", "", ""),
-            TestCase("single alpha", "", "a", "[a]{1,1}"),
-            TestCase("single num", "", "1", "[1]{1,1}"),
-            TestCase("many alpha", "", "abcd", "[abcd]{4,4}"),
-            TestCase("many num", "", "1234", "[1234]{4,4}"),
-            TestCase("alpha equal", "a", "a", "[a]{1,1}"),
+            TestCase("single alpha", "a", "a", "[a]{1,1}"),
+            TestCase("single num", "1", "1", "[1]{1,1}"),
+            TestCase("many alpha", "abcd", "abcd", "[abcd]{4,4}"),
+            TestCase("many num", "4321", "1234", "[1234]{4,4}"),
             TestCase("alpha diff", "a", "b", "[ab]{1,1}"),
             TestCase("alpha num", "a", "1", Fixtures.alnumStar),
             TestCase("alpha mul repeated", "aaaa", "aaaa", "[a]{4,4}"),

--- a/Merger/src/test/kotlin/lushu/Merger/TestUtils/TestNodeBuilder.kt
+++ b/Merger/src/test/kotlin/lushu/Merger/TestUtils/TestNodeBuilder.kt
@@ -7,30 +7,33 @@ import lushu.Merger.Lattice.Node.PwsetNode
 
 class TestNodeBuilder {
     companion object {
-        fun alphaBaseNode(): PwsetNode {
+        fun alphaBaseNode(sensitive: Boolean = false): PwsetNode {
             return PwsetNode(
                 1,
                 setOf<Int>(),
                 Charset(Fixtures.allAlphas),
-                Fixtures.testNodeInterval1To32()
+                Fixtures.testNodeInterval1To32(),
+                sensitive
             )
         }
 
-        fun numBaseNode(): PwsetNode {
+        fun numBaseNode(sensitive: Boolean = false): PwsetNode {
             return PwsetNode(
                 2,
                 setOf<Int>(),
                 Charset(Fixtures.allNums),
-                Fixtures.testNodeInterval1To32()
+                Fixtures.testNodeInterval1To32(),
+                sensitive
             )
         }
 
-        fun punctBaseNode(): PwsetNode {
+        fun punctBaseNode(sensitive: Boolean = false): PwsetNode {
             return PwsetNode(
                 3,
                 setOf<Int>(0, 1),
                 Charset(Fixtures.allPuncts),
-                Fixtures.testNodeInterval1To32()
+                Fixtures.testNodeInterval1To32(),
+                sensitive
             )
         }
 
@@ -48,24 +51,28 @@ class TestNodeBuilder {
         fun alphaIntervalNode(
             chars: Set<Char>,
             intervalMin: Int,
-            intervalMax: Int
+            intervalMax: Int,
+            sensitive: Boolean = false
         ): IntervalNode {
             return IntervalNode(
                 alphaBaseNode(),
                 Charset(chars),
-                Interval(intervalMin, intervalMax)
+                Interval(intervalMin, intervalMax),
+                sensitive
             )
         }
 
         fun punctIntervalNode(
             chars: Set<Char>,
             intervalMin: Int,
-            intervalMax: Int
+            intervalMax: Int,
+            sensitive: Boolean = false
         ): IntervalNode {
             return IntervalNode(
                 punctBaseNode(),
                 Charset(chars),
-                Interval(intervalMin, intervalMax)
+                Interval(intervalMin, intervalMax),
+                sensitive
             )
         }
 


### PR DESCRIPTION
Fixes two bugs:

1. Sensitive propagation when building pwset node in `NodeFactory`
2. Corner case treatment in the `Zipper` class

Also, following improvements:

1. Improve `toString` methods in the node types
2. Add unit tests to make sure sensitive property is being propagated as expected.