### PR TITLE
Include Lushu logo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<div align="center">
+  <span><img src="https://github.com/Vitor-Git15/AddLogo/assets/89043212/4fbc9749-122c-4404-a22c-55bc244d7e04" alt="Lushu Logo" width="200" height="200">
+</div>
+
 # Lushu
 
 _Lushu_ (short for the Chinese 记录树, 录树), is a system that recognizes


### PR DESCRIPTION
This commit adds the Lushu logo to the README.md file, based on the Git repository's standard available at the following link: 'https://github.com/lac-dcc/honey-potion'.